### PR TITLE
reverts import statement ordering

### DIFF
--- a/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
+++ b/logback-classic/src/main/java/ch/qos/logback/classic/util/LogbackMDCAdapter.java
@@ -13,12 +13,12 @@
  */
 package ch.qos.logback.classic.util;
 
-import org.slf4j.spi.MDCAdapter;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
+import org.slf4j.spi.MDCAdapter;
 
 /**
  * A <em>Mapped Diagnostic Context</em>, or MDC in short, is an instrument for

--- a/logback-classic/src/test/java/ch/qos/logback/classic/util/LogbackMDCAdapterTest.java
+++ b/logback-classic/src/test/java/ch/qos/logback/classic/util/LogbackMDCAdapterTest.java
@@ -13,14 +13,18 @@
  */
 package ch.qos.logback.classic.util;
 
-import ch.qos.logback.core.testUtil.RandomUtil;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+import ch.qos.logback.core.testUtil.RandomUtil;
 
 public class LogbackMDCAdapterTest {
 


### PR DESCRIPTION
The previous pull request did not respect the import ordering. This commit reverts the formatting changes made to the import statements while maintaining the code changes made by user dimas.